### PR TITLE
Fix missing tool descriptions

### DIFF
--- a/mcpgenerator/server_tools.go
+++ b/mcpgenerator/server_tools.go
@@ -22,6 +22,11 @@ func (s *MCPServer) SetTools(tools []model.Endpoint) {
 	s.server.DeleteTools(names...)
 	for _, endpoint := range tools {
 		var opts []mcp.ToolOption
+		if endpoint.Description != "" {
+			opts = append(opts, mcp.WithDescription(endpoint.Description))
+		} else if endpoint.Summary != "" {
+			opts = append(opts, mcp.WithDescription(endpoint.Summary))
+		}
 		for _, col := range endpoint.Params {
 			if col.Required {
 				opts = append(opts, ArgumentOption(col, mcp.Required()))

--- a/mcpgenerator/server_tools_test.go
+++ b/mcpgenerator/server_tools_test.go
@@ -1,0 +1,37 @@
+package mcpgenerator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/centralmind/gateway/mcp"
+	"github.com/centralmind/gateway/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetToolsIncludesDescription(t *testing.T) {
+	srv, err := New(nil)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	// initialize server to enable tools capabilities
+	_ = srv.Server().HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+
+	endpoint := model.Endpoint{
+		MCPMethod:   "test_method",
+		Description: "sample description",
+		Params: []model.EndpointParams{
+			{Name: "id", Type: "string"},
+		},
+	}
+
+	srv.SetTools([]model.Endpoint{endpoint})
+
+	resp := srv.Server().HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`))
+	listResp, ok := resp.(mcp.JSONRPCResponse)
+	assert.True(t, ok)
+	tools := listResp.Result.(mcp.ListToolsResult).Tools
+	if assert.Len(t, tools, 1) {
+		assert.Equal(t, "sample description", tools[0].Description)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve custom tool descriptions from gateway config
- test that SetTools adds description

## Testing
- `go test ./...` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_68455bf6478483288c01e8c3f9e8fd48