### PR TITLE
Improve logging and CLI support

### DIFF
--- a/connectors/base.go
+++ b/connectors/base.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/centralmind/gateway/model"
 	"github.com/jmoiron/sqlx"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
 )
 
@@ -27,15 +28,18 @@ func (b *BaseConnector) mapSQLTypeToColumnType(guesser TypeGuesser, sqlType stri
 // InferResultColumns provides a generic implementation for getting result column information
 // This implementation works with any SQL database that supports the database/sql interfaces
 func (b *BaseConnector) InferResultColumns(ctx context.Context, query string, guesser TypeGuesser) ([]model.ColumnSchema, error) {
+	logrus.Infof("Infer columns for query: %s", query)
 	// Prepare the statement to get column information
 	tx, err := b.DB.BeginTxx(ctx, &sql.TxOptions{
 		ReadOnly: true,
 	})
 	if err != nil {
+		logrus.Errorf("BeginTx failed with error: %v", err)
 		return nil, xerrors.Errorf("BeginTx failed with error: %w", err)
 	}
 	stmt, err := tx.PrepareNamedContext(ctx, query)
 	if err != nil {
+		logrus.Errorf("unable to prepare statement: %v", err)
 		return nil, xerrors.Errorf("unable to prepare statement: %w", err)
 	}
 	defer stmt.Close()
@@ -49,6 +53,7 @@ func (b *BaseConnector) InferResultColumns(ctx context.Context, query string, gu
 	// to only fetch metadata without actually executing the full query
 	rows, err := stmt.QueryContext(ctx, prms)
 	if err != nil {
+		logrus.Errorf("unable to execute statement: %v", err)
 		return nil, xerrors.Errorf("unable to execute statement: %w", err)
 	}
 	defer rows.Close()
@@ -56,6 +61,7 @@ func (b *BaseConnector) InferResultColumns(ctx context.Context, query string, gu
 	// Get column types from the result
 	colTypes, err := rows.ColumnTypes()
 	if err != nil {
+		logrus.Errorf("unable to get column types: %v", err)
 		return nil, xerrors.Errorf("unable to get column types: %w", err)
 	}
 

--- a/connectors/init.go
+++ b/connectors/init.go
@@ -76,5 +76,9 @@ func New(tag string, config any) (Connector, error) {
 	if !ok {
 		return nil, xerrors.Errorf("connector: %s not found", tag)
 	}
-	return f(config)
+	conn, err := f(config)
+	if err != nil {
+		return nil, err
+	}
+	return WrapWithLogging(conn), nil
 }

--- a/connectors/logging_wrapper.go
+++ b/connectors/logging_wrapper.go
@@ -1,0 +1,36 @@
+package connectors
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/centralmind/gateway/model"
+)
+
+type loggingConnector struct {
+	Connector
+}
+
+// WrapWithLogging wraps the given connector with logging functionality.
+func WrapWithLogging(inner Connector) Connector {
+	return &loggingConnector{Connector: inner}
+}
+
+func (l loggingConnector) Query(ctx context.Context, endpoint model.Endpoint, params map[string]any) ([]map[string]any, error) {
+	logrus.Infof("SQL query: %s", endpoint.Query)
+	res, err := l.Connector.Query(ctx, endpoint, params)
+	if err != nil {
+		logrus.Errorf("query failed: %v", err)
+	}
+	return res, err
+}
+
+func (l loggingConnector) InferQuery(ctx context.Context, query string) ([]model.ColumnSchema, error) {
+	logrus.Infof("Infer query: %s", query)
+	res, err := l.Connector.InferQuery(ctx, query)
+	if err != nil {
+		logrus.Errorf("infer query failed: %v", err)
+	}
+	return res, err
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/centralmind/gateway/cli"
@@ -33,6 +35,17 @@ func main() {
 		Short:        "gateway cli",
 		Example:      "./gateway help",
 		SilenceUsage: true,
+	}
+	var logLevel string
+	rootCommand.PersistentFlags().StringVar(&logLevel, "log-level", "info", "logging level (trace, debug, info, warn, error)")
+	rootCommand.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		level, err := logrus.ParseLevel(logLevel)
+		if err != nil {
+			return fmt.Errorf("invalid log level %s", logLevel)
+		}
+		logrus.SetOutput(os.Stdout)
+		logrus.SetLevel(level)
+		return nil
 	}
 	cli.RegisterCommand(rootCommand, cli.StartCommand())
 	cli.RegisterCommand(rootCommand, cli.Connectors())


### PR DESCRIPTION
## Summary
- add command line flag `--log-level` to control logrus level
- log SQL query inference and execution
- add logging wrapper around connectors
- remove experimental ClickHouse infer query changes

## Testing
- `go vet ./...` *(fails: Forbidden - unable to download modules)*
- `go test ./...` *(fails: Forbidden - unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_684883b930e083288d201a556aa563c2