### PR TITLE
Fix log timestamp

### DIFF
--- a/cli/discover.go
+++ b/cli/discover.go
@@ -34,13 +34,13 @@ var (
 )
 
 func init() {
-	// Configure logrus for nicer output
+	// Configure logrus for nicer output with timestamps
 	logrus.SetFormatter(&logrus.TextFormatter{
 		DisableLevelTruncation: true,
 		ForceColors:            true,
-		FullTimestamp:          false,
-		TimestampFormat:        "",
-		DisableTimestamp:       true,
+		FullTimestamp:          true,
+		TimestampFormat:        time.RFC3339,
+		DisableTimestamp:       false,
 	})
 }
 


### PR DESCRIPTION
## Summary
- show timestamps for CLI output

## Testing
- `go vet ./...` *(fails: Forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6847e879c558832884e4e0eccda5f085